### PR TITLE
Fix: issue with export in mod.ts

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
 // Copyright 2020 Filippo Rossi. All rights reserved. MIT license.
 
-export { status, Status } from "./status.ts";
+export type { status, Status } from "./status.ts";
 export * from "./codes.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,5 @@
 // Copyright 2020 Filippo Rossi. All rights reserved. MIT license.
 
-export type { status, Status } from "./status.ts";
+export type { Status } from "./status.ts";
+export { status } from "./status.ts";
 export * from "./codes.ts";

--- a/status_test.ts
+++ b/status_test.ts
@@ -2,7 +2,7 @@
 
 import {
   assert,
-  assertStrictEq,
+  assertStrictEquals as assertStrictEq,
   assertThrows,
 } from "https://deno.land/std/testing/asserts.ts";
 


### PR DESCRIPTION
```
alex@DESKTOP-7EE878J:/mnt/c/Users/Alex/source/repos/status$ deno cache mod.ts
Check file:///mnt/c/Users/Alex/source/repos/status/mod.ts
error: TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
export { status, Status } from "./status.ts";
                 ~~~~~~
    at file:///mnt/c/Users/Alex/source/repos/status/mod.ts:3:18
```